### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fork-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 authors = ["Kristof Mattei"]
 description = "Modern fork for Rust"
 license-file = "LICENSE"
@@ -23,6 +23,10 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+# this has 0 performance implications, the binding is compiled away, and it could cause issues
+# when done blindly, plus it makes it harder to debug as you cannot put breakpoints on return
+# values of functions (yet)
+let_and_return = { level = "allow", priority = 127 }
 # this one is debatable. continue is used in places to be explicit, and to guard against
 # issues when refactoring
 needless_continue = { level = "allow", priority = 127 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,7 @@ fn wait_for_failure(pid: i32, timeout_ms: u16) -> Result<(), std::io::Error> {
         // didn't fail within `timeout_ms`
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        Err(std::io::Error::other(
             "Grandchild died before `timeout_ms` expiration",
         ))
     }
@@ -80,31 +79,24 @@ fn wait_for_success(pid: i32) -> Result<(), std::io::Error> {
 
     match ExitCodes::try_from(status) {
         Ok(ExitCodes::Ok) => Ok(()),
-        Ok(ExitCodes::ChildFailedToFork) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Child did not launch correctly",
-        )),
+        Ok(ExitCodes::ChildFailedToFork) => {
+            Err(std::io::Error::other("Child did not launch correctly"))
+        },
 
-        Ok(ExitCodes::ChildSetsidFailed) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Child setsid failed",
-        )),
-        Ok(ExitCodes::GrandchildChdirFailed) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "GrandChild chdir failed",
-        )),
-        Ok(ExitCodes::GrandchildOpenDevNullFailed) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "GrandChild open /dev/null failed",
-        )),
-        Ok(ExitCodes::GrandchildFailedTooSoon) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "GrandChild failed too soon",
-        )),
-        Err(err) => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Unspecified error code: {}", err),
-        )),
+        Ok(ExitCodes::ChildSetsidFailed) => Err(std::io::Error::other("Child setsid failed")),
+        Ok(ExitCodes::GrandchildChdirFailed) => {
+            Err(std::io::Error::other("GrandChild chdir failed"))
+        },
+        Ok(ExitCodes::GrandchildOpenDevNullFailed) => {
+            Err(std::io::Error::other("GrandChild open /dev/null failed"))
+        },
+        Ok(ExitCodes::GrandchildFailedTooSoon) => {
+            Err(std::io::Error::other("GrandChild failed too soon"))
+        },
+        Err(err) => Err(std::io::Error::other(format!(
+            "Unspecified error code: {}",
+            err
+        ))),
     }
 }
 


### PR DESCRIPTION
- **chore(deps): update rust:1.86.0 docker digest to c42032c**
- **chore(deps): update rust:1.86.0 docker digest to a2ccb7c**
- **chore(deps): update rust:1.86.0 docker digest to 300ec56**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to d9c118e**
- **chore(deps): update returntocorp/semgrep docker tag to v1.121.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.3**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.122.0**
- **chore(deps): update node.js to v22.15.1**
- **chore(deps): update docker/build-push-action action to v6.17.0**
- **chore(deps): update rust docker tag to v1.87.0**
- **chore(deps): update rust to v1.87.0**
- **chore(deps): update codecov/codecov-action action to v5.4.3**
- **chore(deps): update rust:1.87.0 docker digest to 5e33ae7**
- **chore(deps): update npm to >=11.4.0**
- **chore(deps): update github/codeql-action action to v3.28.18**
- **fix: disable clippy 1.87.0 let_and_return**
- **chore: change wording**
