### PR TITLE
update from upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "fork-rs",
   "type": "module",
-  "packageManager": "pnpm@10.16.1",
+  "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
   "engines": {
     "node": "24.8.0",
-    "pnpm": "10.16.1"
+    "pnpm": "10.17.0"
   },
   "scripts": {
     "format": "prettier --write ."


### PR DESCRIPTION
- **chore(deps): update rust:1.89.0-trixie docker digest to 1ca9500**
- **chore(deps): update returntocorp/semgrep docker tag to v1.136.0**
- **chore(deps): update rust:1.89.0-trixie docker digest to 85456cd**
- **chore(deps): update rust:1.89.0-trixie docker digest to 9e1b362**
- **chore(deps): update github/codeql-action action to v3.30.3**
- **chore(deps): update node.js to v24.8.0**
- **chore(deps): update pnpm to v10.16.0**
- **chore(deps): update pnpm to v10.16.1**
- **chore(deps): update rust:1.89.0-trixie docker digest to 57407b3**
- **fix: set sha for pnpm**
