### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,16 +339,18 @@ jobs:
           fail_ci_if_error: true
           files: reports/lcov.info
           plugins: ""
+          report_type: "coverage"
           use_oidc: true
 
-      - name: Upload test results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      - name: Upload test results (to Codecov.io)
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           disable_search: true
-          # doesn't exist here... yet
-          # disable_telem: true
+          disable_telem: true
           fail_ci_if_error: true
           files: reports/results.xml
+          plugins: ""
+          report_type: "test_results"
           use_oidc: true
 
       - name: Fail if tests failed
@@ -798,6 +800,7 @@ jobs:
       - cargo-clippy-and-report
       - cargo-fmt
       - cargo-test-and-report
+      - pre-build-cargo-edit
       - docker-build
       - docker-publish
       - docker-attest


### PR DESCRIPTION
- **chore(deps): update rust:1.92.0-slim-trixie docker digest to 0d8bf26**
- **chore(deps): update pnpm to v10.26.0**
- **chore(deps): update codecov/test-results-action action to v1.2.1**
- **chore: codecov/test-results-action is deprecated**
- **chore: require `pre-build-cargo-edit` success or skip, but not failure**
